### PR TITLE
docs: fix a typo in the version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To view this documentation, start with the [Index](doc_source/index.md).
 
 This repository contains the open source version of the official [AWS SDK for JavaScript V3 developer guide, version 3](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/welcome.html).
 
-The source code for the AWS SDK for JavaScript 2.0 is also on GitHub at https://github.com/aws/aws-sdk-js-v3.
+The source code for the AWS SDK for JavaScript 3.0 is also on GitHub at https://github.com/aws/aws-sdk-js-v3.
 
 ## Recent Updates
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
It looked like the version number on the README should say `3.0` rather than `2.0` - if that is correct, this PR changes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
